### PR TITLE
新しい順に表示するようcreatedAtを設定

### DIFF
--- a/lib/models/comment.dart
+++ b/lib/models/comment.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class Comment {
   Comment({
     this.id = '',
@@ -5,10 +7,12 @@ class Comment {
     this.author = '',
     this.authorImage = '',
     this.text = '',
+    required this.createdAt,
   });
   String id;
   String authorId;
   String author;
   String authorImage;
   String text;
+  Timestamp? createdAt;
 }

--- a/lib/models/post.dart
+++ b/lib/models/post.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class Post {
   Post({
     this.id = '',
@@ -6,6 +8,7 @@ class Post {
     this.authorImage = '',
     this.bookImage = '',
     this.text = '',
+    required this.createdAt,
   });
   String id;
   String author;
@@ -13,4 +16,5 @@ class Post {
   String authorImage;
   String? bookImage;
   String text;
+  Timestamp? createdAt;
 }

--- a/lib/view_models/time_line_model.dart
+++ b/lib/view_models/time_line_model.dart
@@ -43,7 +43,8 @@ class TimeLineModel extends ChangeNotifier {
       'authorId': Authentication.myAccount!.id,
       'authorImage': Authentication.myAccount!.imagePath,
       'bookImage': postBooks?.imgURL,
-      'text': postsCommentController.text
+      'text': postsCommentController.text,
+      'createdAt': Timestamp.now(),
     });
 
     await usersPostDoc.set({
@@ -55,8 +56,10 @@ class TimeLineModel extends ChangeNotifier {
   }
 
   void fetchPost() {
-    final Stream<QuerySnapshot> snapshots =
-        _firestoreInstance.collection('posts').snapshots();
+    final Stream<QuerySnapshot> snapshots = _firestoreInstance
+        .collection('posts')
+        .orderBy('createdAt', descending: true)
+        .snapshots();
 
     snapshots.listen((QuerySnapshot snapshot) {
       final List<Post> posts = snapshot.docs.map((DocumentSnapshot document) {
@@ -68,6 +71,7 @@ class TimeLineModel extends ChangeNotifier {
           authorImage: data['authorImage'],
           bookImage: data['bookImage'],
           text: data['text'],
+          createdAt: data['createdAt'],
         );
       }).toList();
       this.posts = posts;
@@ -98,7 +102,8 @@ class TimeLineModel extends ChangeNotifier {
       'authorId': Authentication.myAccount!.id,
       'author': Authentication.myAccount!.name,
       'author_image': Authentication.myAccount!.imagePath,
-      'text': commentController.text
+      'text': commentController.text,
+      'createdAt': Timestamp.now(),
     });
 
     await usersCommentDoc.set({
@@ -113,6 +118,7 @@ class TimeLineModel extends ChangeNotifier {
         .collection('posts')
         .doc(post.id)
         .collection('postsComments')
+        .orderBy('createdAt', descending: false)
         .snapshots();
 
     snapshots.listen((QuerySnapshot snapshot) {
@@ -125,6 +131,7 @@ class TimeLineModel extends ChangeNotifier {
           authorId: data['authorId'],
           authorImage: data['author_image'],
           text: data['text'],
+          createdAt: data['createdAt'],
         );
       }).toList();
       postComments = comments;


### PR DESCRIPTION
タイムラインページにおいて、投稿を新しい順に、その投稿に対してのコメントを古い順に並ぶように修正しました